### PR TITLE
Autoload add-zsh-hook prior to call it

### DIFF
--- a/guri.zsh-theme
+++ b/guri.zsh-theme
@@ -160,6 +160,8 @@ guri-ret-status() {
     echo "%(?:%{$fg_bold[green]%}$GURI_PROMPT_SYMBOL:%{$fg_bold[red]%}$GURI_PROMPT_SYMBOL) "
 }
 
+autoload -Uz add-zsh-hook
+
 add-zsh-hook chpwd guri-run-dotfile
 add-zsh-hook precmd guri-venv-indicator
 


### PR DESCRIPTION
The proper way to use zsh hooks is to autoload the function before using it